### PR TITLE
Fix pegged numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.15.4
+numpy
 opencv-python==3.4.3.18
 PyQt5==5.11.3
 PyQt5-sip==4.19.13


### PR DESCRIPTION
New version of atom will cause conflicts if we explicitly peg numpy in our requirements